### PR TITLE
Don't block forever on startup if there's a misbehaving window

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -21,7 +21,7 @@ void update_user_environment(std::initializer_list<std::pair<std::wstring, std::
 			throw std::system_error(err, std::system_category());
 	}
 
-	if (!SendMessageW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)L"Environment"))
+	if (!SendNotifyMessageW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)L"Environment"))
 		throw std::system_error(::GetLastError(), std::system_category());
 }
 


### PR DESCRIPTION
On my systems, cngeant sometimes blocks forever on startup (just after creating the Cygwin socket; the agent works, but the UI is not displayed).  This appears to be because I have some unknown window which is not processing messages, so the SendMessageW(HWND_BROADCAST...) to tell processes to update their environment variables blocks forever.

So instead I've changed that to SendNotifyMessageW which doesn't block.