### PR TITLE
Reply to unknown message types with SSH_AGENT_FAILURE

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -458,7 +458,8 @@ bool agent::process_message(ssh_writer & wr, std::string_view msg)
 		return true;
 	}
 	default:
-		return false;
+		wr.push_back(5); // SSH_AGENT_FAILURE
+		return true;
 	}
 }
 


### PR DESCRIPTION
Recent versions of the OpenSSH client try to negotiate protocol extensions (SSH_AGENTC_EXTENSION messages) with the agent.  Since we don't support extensions, we should reply to such messages (and any other unknown messages) with SSH_AGENT_FAILURE rather than abruptly closing, so that authentication continues without extensions.